### PR TITLE
Bunch of fixes to service broker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
+apply plugin: 'application'
+mainClassName = 'com.yugabyte.servicebroker.YugaByteServiceBrokerApplication'
 
 group = 'org.yb'
 version = '0.0.1'

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,6 @@
+
+---
+applications:
+- name: yugabyte-sb
+  random-route: false
+  path: build/libs/servicebroker-0.0.1.jar

--- a/src/main/java/com/yugabyte/servicebroker/service/YugaByteMetadataService.java
+++ b/src/main/java/com/yugabyte/servicebroker/service/YugaByteMetadataService.java
@@ -57,8 +57,6 @@ public class YugaByteMetadataService {
     String url = String.format("%s/providers", adminService.getApiBaseUrl());
     JsonNode response = adminService.doGet(url);
     provider = StreamSupport.stream(response.spliterator(), false )
-        .filter( provider -> provider.get("code").asText().equals("kubernetes"))
-        .filter( provider -> provider.get("config").get("KUBECONFIG_PROVIDER").asText().equals("pks"))
         .findFirst().orElse(null);
     if (provider != null) {
       String providerBaseUrl = String.format("%s/providers/%s",
@@ -153,8 +151,8 @@ public class YugaByteMetadataService {
     ybMetadata.put("imageUrl", "https://assets.yugabyte.com/yugabyte_full_logo.png");
     ybMetadata.put("longDescription", "YugaByte DB Service");
     ybMetadata.put("providerDisplayName", "YugaByte DB");
-    ybMetadata.put("documentationUrl", "https://github.com/YugaByte/yugabyte-db");
-    ybMetadata.put("supportUrl", "https://github.com/YugaByte/yugabyte-db");
+    ybMetadata.put("documentationUrl", "https://docs.yugabyte.com");
+    ybMetadata.put("supportUrl", "mailto:support@yugabyte.com");
     return ybMetadata;
   }
 }


### PR DESCRIPTION
- Add manifest.yml to support cf push, tested by running 
`./gradlew build`
`cf push`

- Add application plugin to run the application locally, tested by running
`./gradlew run`

- Relaxed the filtering on the metadata service to include non kubernetes providers as well.
- Update docs and support link