### PR TITLE
Fix pivotal-mysql version requirement

### DIFF
--- a/tile.yml
+++ b/tile.yml
@@ -49,4 +49,4 @@ forms:
 
 requires_product_versions:
 - name: pivotal-mysql
-  version: '~> 2.0'
+  version: '>= 2.0'


### PR DESCRIPTION
Hit a warning in CI/CD of pivotal, so address that
run 
`tile build`
