### PR TITLE
Add Auth hooks for YCQL and YEDIS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
 	compile group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa'
     compile 'mysql:mysql-connector-java'
+    compile group: 'com.yugabyte', name: 'cassandra-driver-core', version: '3.2.0-yb-18'
+	compile group: 'com.yugabyte', name: 'jedis', version: '2.9.0-yb-11'
 
 	testCompile("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/java/com/yugabyte/servicebroker/service/YugaByteAdminService.java
+++ b/src/main/java/com/yugabyte/servicebroker/service/YugaByteAdminService.java
@@ -23,7 +23,7 @@ import com.yugabyte.servicebroker.model.ServiceInstance;
 import com.yugabyte.servicebroker.repository.ServiceInstanceRepository;
 import com.yugabyte.servicebroker.utils.CommonUtils;
 import com.yugabyte.servicebroker.utils.YEDISClient;
-import com.yugabyte.servicebroker.utils.YQLClient;
+import com.yugabyte.servicebroker.utils.YCQLClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
@@ -190,18 +190,18 @@ public class YugaByteAdminService {
                                                          List<ServiceBinding> existingBindings) {
     String universeUUID = getUniverseUUIDFromServiceInstance(instanceId);
     String url = String.format("%s/universes/%s/yqlservers", getApiBaseUrl(), universeUUID);
-    String yqlServers = doGetRaw(url);
+    String ycqlServers = doGetRaw(url);
     url = String.format("%s/universes/%s/redisservers", getApiBaseUrl(), universeUUID);
     String yedisServers = doGetRaw(url);
     Map<String, Object> endpoints = new HashMap<>();
-    List<HostAndPort> yqlHostAndPorts =
-        CommonUtils.convertToHostPorts(yqlServers.replaceAll("^\"|\"$", ""));
+    List<HostAndPort> ycqlHostAndPorts =
+        CommonUtils.convertToHostPorts(ycqlServers.replaceAll("^\"|\"$", ""));
     List<HostAndPort> yedisHostAndPorts =
         CommonUtils.convertToHostPorts(yedisServers.replaceAll("^\"|\"$", ""));
-    YQLClient yqlClient = new YQLClient(yqlHostAndPorts);
+    YCQLClient ycqlClient = new YCQLClient(ycqlHostAndPorts);
     YEDISClient yedisClient = new YEDISClient(yedisHostAndPorts);
     try {
-      endpoints.put("yql", yqlClient.getCredentials());
+      endpoints.put("ycql", ycqlClient.getCredentials());
     } catch (Exception e) {}
 
     try {

--- a/src/main/java/com/yugabyte/servicebroker/service/YugaByteBindingService.java
+++ b/src/main/java/com/yugabyte/servicebroker/service/YugaByteBindingService.java
@@ -41,7 +41,6 @@ public class YugaByteBindingService implements ServiceInstanceBindingService {
     this.bindingRepository = bindingRepository;
   }
 
-
   @Override
   public CreateServiceInstanceBindingResponse createServiceInstanceBinding(CreateServiceInstanceBindingRequest request) {
     String bindingId = request.getBindingId();
@@ -54,7 +53,10 @@ public class YugaByteBindingService implements ServiceInstanceBindingService {
           .bindingExisted(true)
           .credentials(binding.get().getCredentials());
     } else {
-      Map<String, Object> serviceEndpoints = adminService.getUniverseServiceEndpoints(request.getServiceInstanceId());
+      Map<String, Object> serviceEndpoints = adminService.getUniverseServiceEndpoints(
+          request.getServiceInstanceId(),
+          bindingRepository.findAll()
+      );
       ServiceBinding serviceBinding =
           new ServiceBinding(request.getBindingId(), request.getServiceInstanceId(), serviceEndpoints);
       bindingRepository.save(serviceBinding);

--- a/src/main/java/com/yugabyte/servicebroker/service/YugaByteInstanceService.java
+++ b/src/main/java/com/yugabyte/servicebroker/service/YugaByteInstanceService.java
@@ -59,6 +59,8 @@ public class YugaByteInstanceService implements ServiceInstanceService {
       return responseBuilder.build();
     } else {
       JsonNode params = metadataService.getClusterPayload(request);
+      params = adminService.configureUniverse(params);
+      params = metadataService.updateGflags(params, request);
       JsonNode response = adminService.createUniverse(params);
       if (response.has("error")) {
         throw new YugaByteServiceException(response.get("error").asText());

--- a/src/main/java/com/yugabyte/servicebroker/utils/CommonUtils.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/CommonUtils.java
@@ -1,0 +1,67 @@
+/* Copyright (c) YugaByte, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.yugabyte.servicebroker.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.net.HostAndPort;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class CommonUtils {
+  private static int RANDOM_STRING_LENGTH = 12;
+  private static String ALPHABETIC_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  private static String NUMBERIC_CHARS = "0123456789";
+
+  public static String generateRandomString(boolean onlyAlphabets) {
+    String randomChars = onlyAlphabets ? ALPHABETIC_CHARS : ALPHABETIC_CHARS + NUMBERIC_CHARS;
+    return new SecureRandom().ints(RANDOM_STRING_LENGTH, 0, randomChars.length())
+        .mapToObj(idx -> "" + randomChars.charAt(idx))
+        .collect(Collectors.joining());
+  }
+
+  public static List<HostAndPort> convertToHostPorts(String connectString) {
+    String[] hostPortStrings = connectString.split(",");
+    List<HostAndPort> hostAndPorts = new ArrayList<>();
+    for (String hostPortString : hostPortStrings) {
+      hostAndPorts.add(HostAndPort.fromString(hostPortString));
+    }
+    return hostAndPorts;
+  }
+
+  public static Optional<JsonNode> getCluster(JsonNode clusters, String clusterType) {
+    return StreamSupport.stream(clusters.spliterator(), false).filter(
+        (cluster) -> cluster.get("clusterType").asText().equals(clusterType)
+    ).findFirst();
+  }
+
+  public static ArrayNode convertGflagMapToJson(Map<String, Object> gflagsMap) {
+    ObjectMapper mapper = new ObjectMapper();
+    ArrayNode gFlags = mapper.createArrayNode();
+    gflagsMap.forEach((flagName, flagValue) -> {
+      ObjectNode gFlag = mapper.createObjectNode();
+      gFlag.put("name", flagName);
+      gFlag.put("value", flagValue.toString());
+      gFlags.add(gFlag);
+    });
+    return gFlags;
+  }
+}

--- a/src/main/java/com/yugabyte/servicebroker/utils/YBClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YBClient.java
@@ -1,0 +1,42 @@
+/* Copyright (c) YugaByte, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.yugabyte.servicebroker.utils;
+
+import com.google.common.net.HostAndPort;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class YBClient {
+  private List<HostAndPort> serviceHostPorts;
+
+  protected List<HostAndPort> getServiceHostPorts() { return serviceHostPorts; }
+  protected abstract int getDefaultPort();
+  protected abstract Map<String, String> createAuth();
+
+  @Autowired
+  public YBClient(List<HostAndPort> serviceHosts) {
+    this.serviceHostPorts = serviceHosts;
+  }
+
+  public Map<String, String> getCredentials() {
+    String serviceHost = serviceHostPorts.stream().map(sh -> sh.getHostText()).collect(Collectors.joining( "," ));
+    int servicePort = serviceHostPorts.get(0).getPortOrDefault(getDefaultPort());
+    Map<String, String> credentials =  createAuth();
+    credentials.put("host", serviceHost);
+    credentials.put("port", String.valueOf(servicePort));
+    return credentials;
+  }
+}

--- a/src/main/java/com/yugabyte/servicebroker/utils/YCQLClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YCQLClient.java
@@ -23,20 +23,20 @@ import java.util.Map;
 
 import static com.yugabyte.servicebroker.utils.CommonUtils.generateRandomString;
 
-public class YQLClient extends YBClient {
+public class YCQLClient extends YBClient {
   private static String DEFAULT_CASSANDRA_USER = "cassandra";
   private static String DEFAULT_CASSANDRA_PASSWORD = "cassandra";
-  private static int DEFAULT_YQL_PORT = 9042;
+  private static int DEFAULT_YCQL_PORT = 9042;
 
   private Session session;
-  public YQLClient(List<HostAndPort> serviceHosts) {
+  public YCQLClient(List<HostAndPort> serviceHosts) {
     super(serviceHosts);
 
     Cluster.Builder builder = Cluster.builder();
     getServiceHostPorts().forEach( serviceIpPort -> {
       builder.addContactPointsWithPorts(new InetSocketAddress(
           serviceIpPort.getHostText(),
-          serviceIpPort.getPortOrDefault(DEFAULT_YQL_PORT)
+          serviceIpPort.getPortOrDefault(DEFAULT_YCQL_PORT)
       ));
     });
     builder.withCredentials(DEFAULT_CASSANDRA_USER, DEFAULT_CASSANDRA_PASSWORD);
@@ -46,7 +46,7 @@ public class YQLClient extends YBClient {
 
   @Override
   protected int getDefaultPort() {
-    return DEFAULT_YQL_PORT;
+    return DEFAULT_YCQL_PORT;
   }
 
   @Override

--- a/src/main/java/com/yugabyte/servicebroker/utils/YEDISClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YEDISClient.java
@@ -1,0 +1,75 @@
+/* Copyright (c) YugaByte, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.yugabyte.servicebroker.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HostAndPort;
+import com.yugabyte.servicebroker.model.ServiceBinding;
+import org.springframework.beans.factory.annotation.Autowired;
+import redis.clients.jedis.Jedis;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.yugabyte.servicebroker.utils.CommonUtils.generateRandomString;
+
+public class YEDISClient extends YBClient {
+  private static int DEFAULT_YEDIS_PORT = 6379;
+  private Jedis client;
+  List<ServiceBinding> bindings;
+
+  @Override
+  protected int getDefaultPort() {
+    return DEFAULT_YEDIS_PORT;
+  }
+
+  @Autowired
+  public YEDISClient(List<HostAndPort> serviceHosts) {
+    super(serviceHosts);
+    HostAndPort hostAndPort = serviceHosts.get(0);
+    client = new Jedis(hostAndPort.getHostText(), hostAndPort.getPortOrDefault(DEFAULT_YEDIS_PORT));
+    client.connect();
+  }
+
+  @Override
+  protected Map<String, String> createAuth() {
+    Map<String, String> credentials = new HashMap();
+    // We would only call this method the first time to create a auth, after that, we would just fetch
+    // the auth from existing service binding.
+    ObjectMapper mapper = new ObjectMapper();
+    if (bindings.size() > 0) {
+      bindings.forEach((binding) -> {
+        // We need to check this to handle older credentials which were not Map
+        if (binding.getCredentials().get("yedis") instanceof Map) {
+          Map<String, Object> oldCredentials = (Map<String, Object>) binding.getCredentials().get("yedis");
+          if (oldCredentials.containsKey("password")) {
+            credentials.put("password", oldCredentials.get("password").toString());
+          }
+        }
+      });
+    }
+    if (credentials.isEmpty()) {
+      String password = generateRandomString(false);
+      client.configSet("requirepass", password);
+      client.flushAll();
+      client.disconnect();
+      credentials.put("password", password);
+    }
+    return credentials;
+  }
+
+  public void setExistingBindings(List<ServiceBinding> bindings) {
+    this.bindings = bindings;
+  }
+}

--- a/src/main/java/com/yugabyte/servicebroker/utils/YQLClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YQLClient.java
@@ -1,0 +1,66 @@
+/* Copyright (c) YugaByte, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.  See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.yugabyte.servicebroker.utils;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import com.google.common.net.HostAndPort;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.yugabyte.servicebroker.utils.CommonUtils.generateRandomString;
+
+public class YQLClient extends YBClient {
+  private static String DEFAULT_CASSANDRA_USER = "cassandra";
+  private static String DEFAULT_CASSANDRA_PASSWORD = "cassandra";
+  private static int DEFAULT_YQL_PORT = 9042;
+
+  private Session session;
+  public YQLClient(List<HostAndPort> serviceHosts) {
+    super(serviceHosts);
+
+    Cluster.Builder builder = Cluster.builder();
+    getServiceHostPorts().forEach( serviceIpPort -> {
+      builder.addContactPointsWithPorts(new InetSocketAddress(
+          serviceIpPort.getHostText(),
+          serviceIpPort.getPortOrDefault(DEFAULT_YQL_PORT)
+      ));
+    });
+    builder.withCredentials(DEFAULT_CASSANDRA_USER, DEFAULT_CASSANDRA_PASSWORD);
+    Cluster cluster = builder.build();
+    session = cluster.connect();
+  }
+
+  @Override
+  protected int getDefaultPort() {
+    return DEFAULT_YQL_PORT;
+  }
+
+  @Override
+  protected Map<String, String> createAuth() {
+    // Cassandra username are all lowercase and avoid numbers in the beginning.
+    String username = generateRandomString(true).toLowerCase();
+    String password = generateRandomString(false);
+    String createRole = "CREATE ROLE " + username + " with superuser = false " +
+        "and login = true and password = '" + password + "'";
+    session.execute(createRole);
+    session.close();
+    Map<String, String> credentials = new HashMap();
+    credentials.put("username", username);
+    credentials.put("password", password);
+    return credentials;
+  }
+}


### PR DESCRIPTION
- Create YQL and YEDIS clients to create Auth
- Add logic to create Auth while service binding creation
- Change the metadata for service binding

```
curl -X PUT \
  http://localhost:8080/v2/service_instances/270966a5-974e-4d46-a3bb-c3d480e5018a/service_bindings/bind-1 \
  -H 'Content-Type: application/json' \
  -H 'cache-control: no-cache' \
  -d '{
	"binding_id": "bind-1",
	"service_id": "270966a5-974e-4d46-a3bb-c3d480e5018a",
	"plan_id": "xsmall"
}'
```
```
{
    "credentials": {
        "yql": {
            "password": "xxxxxxxxxxxx",
            "port": "9042",
            "host": "10.151.0.4,10.151.0.5,10.151.0.6",
            "username": "xxxxxxxxxxxx"
        },
        "yedis": {
            "password": "xxxxxxxxx",
            "port": "6379",
            "host": "10.151.0.4,10.151.0.5,10.151.0.6"
        }
    }
}
```
