### PR TITLE
Make mysql plan configurable from OpsManager

### DIFF
--- a/tile.yml
+++ b/tile.yml
@@ -14,7 +14,7 @@ packages:
     memory: 1G
   auto_services:
   - name: p.mysql
-    plan: db-small
+    plan: (( .properties.auto_service_mysql_db_plan.value ))
 
   enable_global_access_to_plans: true
 
@@ -46,6 +46,14 @@ forms:
   - name: yugabyte_admin_password
     type: secret
     label: YugaByte Admin Password
+- name: auto-services-form
+  label: Auto services Config
+  description: Auto Services Configuration
+  properties:
+  - name: auto_service_mysql_db_plan
+    type: string
+    label: MySQL DB plan name
+    default: db-small
 
 requires_product_versions:
 - name: pivotal-mysql


### PR DESCRIPTION
Tested by running 
`tile build`

And deploying the tile in PCF.
<img width="983" alt="screen shot 2018-11-28 at 11 42 20 am" src="https://user-images.githubusercontent.com/5263706/49177614-8adca400-f302-11e8-8b4d-635ca206360d.png">
