### PR TITLE
Check the service instance name to not have special characters.

### DIFF
--- a/src/main/java/com/yugabyte/servicebroker/service/YugaByteMetadataService.java
+++ b/src/main/java/com/yugabyte/servicebroker/service/YugaByteMetadataService.java
@@ -133,9 +133,14 @@ public class YugaByteMetadataService {
     }
 
     // Override the defaults based on parameters passed.
-    String universeName=
+    String universeName =
         parameters.getOrDefault("universe_name",
-            "universe-" + instanceId.substring(0, 5)).toString();
+            "service-instance-" + instanceId.substring(0, 8)).toString();
+
+    if (!universeName.matches("^[a-zA-Z0-9-]*$")) {
+      throw new YugaByteServiceException("Invalid Universe Name : " + universeName);
+    }
+
     String ybSoftwareVersion =
         parameters.getOrDefault("yb_version", ybReleases.get(0)).toString();
 


### PR DESCRIPTION
Added universe name validation 
tested by deploying the service broker
`cf push`
`cf create-service yugabyte-db x-small demo_1 -c '{"universe_name": "demo_1"}'`