### PR TITLE
Add CQL role handling

### DIFF
--- a/src/main/java/com/yugabyte/servicebroker/service/YugaByteBindingService.java
+++ b/src/main/java/com/yugabyte/servicebroker/service/YugaByteBindingService.java
@@ -54,7 +54,7 @@ public class YugaByteBindingService implements ServiceInstanceBindingService {
           .credentials(binding.get().getCredentials());
     } else {
       Map<String, Object> serviceEndpoints = adminService.getUniverseServiceEndpoints(
-          request.getServiceInstanceId()
+          request
       );
       ServiceBinding serviceBinding =
           new ServiceBinding(request.getBindingId(), request.getServiceInstanceId(), serviceEndpoints);

--- a/src/main/java/com/yugabyte/servicebroker/utils/YBClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YBClient.java
@@ -26,13 +26,24 @@ import java.util.stream.Collectors;
 public abstract class YBClient {
   public enum ClientType {
     YCQL,
-    YEDIS
+    YEDIS;
+
+    public YBClient getInstance(List<HostAndPort> serviceHosts,
+                                YugaByteConfigRepository yugaByteConfigRepository) {
+      switch (this) {
+        case YCQL:
+          return new YCQLClient(serviceHosts, yugaByteConfigRepository);
+        case YEDIS:
+          return new YEDISClient(serviceHosts, yugaByteConfigRepository);
+      }
+      return null;
+    }
   }
 
   private List<HostAndPort> serviceHostPorts;
   protected List<HostAndPort> getServiceHostPorts() { return serviceHostPorts; }
   protected abstract int getDefaultPort();
-  protected abstract Map<String, String> createAuth();
+  protected abstract Map<String, String> createAuth(Map<String, Object> parameters);
   public abstract void deleteAuth(Map<String, String> credentials);
 
   private YugaByteConfigRepository yugaByteConfigRepository;
@@ -56,23 +67,12 @@ public abstract class YBClient {
     yugaByteConfigRepository.save(newConfig);
   }
 
-  public Map<String, String> getCredentials() {
+  public Map<String, String> getCredentials(Map<String, Object> parameters) {
     String serviceHost = serviceHostPorts.stream().map(sh -> sh.getHostText()).collect(Collectors.joining( "," ));
     int servicePort = serviceHostPorts.get(0).getPortOrDefault(getDefaultPort());
-    Map<String, String> credentials =  createAuth();
+    Map<String, String> credentials =  createAuth(parameters);
     credentials.put("host", serviceHost);
     credentials.put("port", String.valueOf(servicePort));
     return credentials;
-  }
-
-  public static YBClient getClientForType(ClientType type, List<HostAndPort> serviceHosts,
-                                          YugaByteConfigRepository yugaByteConfigRepository) {
-    switch (type) {
-      case YCQL:
-        return new YCQLClient(serviceHosts, yugaByteConfigRepository);
-      case YEDIS:
-        return new YEDISClient(serviceHosts, yugaByteConfigRepository);
-    }
-    return null;
   }
 }

--- a/src/main/java/com/yugabyte/servicebroker/utils/YBClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YBClient.java
@@ -43,6 +43,9 @@ public abstract class YBClient {
   private List<HostAndPort> serviceHostPorts;
   protected List<HostAndPort> getServiceHostPorts() { return serviceHostPorts; }
   protected abstract int getDefaultPort();
+  /* Parameters can be any additional params that get sent at the time of service key creation
+     For now we only check to see if there is a param named `role` and use it, rest all are ignored.
+  */
   protected abstract Map<String, String> createAuth(Map<String, Object> parameters);
   public abstract void deleteAuth(Map<String, String> credentials);
 

--- a/src/main/java/com/yugabyte/servicebroker/utils/YCQLClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YCQLClient.java
@@ -81,7 +81,7 @@ public class YCQLClient extends YBClient {
 
   private void createSystemRoles() {
     // We will also create two roles in the system, one is admin and other is
-    // readonly, off course users can add their own roles and grant them.
+    // readonly, of course users can add their own roles and grant them.
     for (CQLRole role : CQLRole.values()) {
       String createRole = String.format("CREATE ROLE IF NOT EXISTS %s", role);
       session.execute(createRole);

--- a/src/main/java/com/yugabyte/servicebroker/utils/YEDISClient.java
+++ b/src/main/java/com/yugabyte/servicebroker/utils/YEDISClient.java
@@ -34,13 +34,17 @@ public class YEDISClient extends YBClient {
   public YEDISClient(List<HostAndPort> serviceHosts,
                      YugaByteConfigRepository yugaByteConfigRepository) {
     super(serviceHosts, yugaByteConfigRepository);
-    HostAndPort hostAndPort = serviceHosts.get(0);
+  }
+
+  public Jedis getSession() {
+    HostAndPort hostAndPort = getServiceHostPorts().get(0);
     client = new Jedis(hostAndPort.getHostText(), hostAndPort.getPortOrDefault(DEFAULT_YEDIS_PORT));
     client.connect();
+    return client;
   }
 
   @Override
-  protected Map<String, String> createAuth() {
+  protected Map<String, String> createAuth(Map<String, Object> parameters) {
     // We would only call this method the first time to create a auth, after that, we would just fetch
     // the auth from yugabyte_config table.
     Map<String, String> credentials = getAdminCredentials(
@@ -52,6 +56,7 @@ public class YEDISClient extends YBClient {
       return credentials;
     }
 
+    client = getSession();
     String password = generateRandomString(false);
     client.configSet("requirepass", password);
     client.flushAll();

--- a/src/test/java/com/yugabyte/servicebroker/service/YugaByteAdminServiceTest.java
+++ b/src/test/java/com/yugabyte/servicebroker/service/YugaByteAdminServiceTest.java
@@ -17,15 +17,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.yugabyte.servicebroker.YugaByteServiceTestConfig;
 import com.yugabyte.servicebroker.exception.YugaByteServiceException;
-import com.yugabyte.servicebroker.model.ServiceInstance;
 import com.yugabyte.servicebroker.repository.ServiceInstanceRepository;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -427,25 +424,5 @@ public class YugaByteAdminServiceTest  {
     } catch (YugaByteServiceException ye) {
       assertEquals("Unable to delete universe " + universeUUID, ye.getLocalizedMessage());
     }
-  }
-
-  @Ignore
-  // TODO: ADD TESTS
-  public void testGetEndpointForServiceType() {
-    UUID universeUUID = UUID.randomUUID();
-    CreateServiceInstanceRequest request = CreateServiceInstanceRequest.builder()
-        .serviceDefinitionId("sd-1")
-        .planId("plan-1")
-        .serviceInstanceId("instance-1").build();
-    ServiceInstance serviceInstance = new ServiceInstance(request, universeUUID.toString());
-    instanceRepository.save(serviceInstance);
-    mockServer.expect(ExpectedCount.once(),
-        requestTo("http://localhost:9000/api/universes/" + universeUUID + "/yqlservers"))
-        .andExpect(method(HttpMethod.GET))
-        .andRespond(withStatus(HttpStatus.OK)
-            .contentType(MediaType.APPLICATION_JSON)
-            .body("10.0.0.1:9042,10.0.0.2:9042,10.0.0.3:9042")
-        );
-    adminService.getUniverseServiceEndpoints("instance-1");
   }
 }


### PR DESCRIPTION
Tested by making the service broker point to k8s yugaware

Created Service
```
curl -X PUT \
  http://localhost:8080/v2/service_instances/270966a5-974e-4d46-a3bb-c3d480e5011m \
  -H 'Content-Type: application/json' \
  -d '{
	"service_id": "demo",
	"plan_id": "xsmall",
	"parameters": {
		"universe_name": "demo",
		"provider_type": "kubernetes",
		"kube_provider": "gke"
	}
}'
```
Create service binding with additional params 
```
curl -X PUT \
  http://localhost:8080/v2/service_instances/270966a5-974e-4d46-a3bb-c3d480e5011m/service_bindings/bind8.3 \
  -H 'Content-Type: application/json' \
  -H 'X-AUTH-TOKEN: 6d502312-fcc0-4561-b194-a8e14fd60543' \
  -H 'cache-control: no-cache' \
  -d '{
	"binding_id": "bind-4",
	"service_id": "270966a5-974e-4d46-a3bb-c3d480e5011m",
	"plan_id": "xsmall",
	"parameters": {
		"role": "read_only"
		
	}
}'
```

Fixes #22  